### PR TITLE
Fix incorrect manim test

### DIFF
--- a/manim_test.py
+++ b/manim_test.py
@@ -23,9 +23,11 @@ def main(args):
             print('invalid path:', path)
             continue
         for language in ['armenian', 'english']:
-            subprocess.run(['python', 'qarakusi.am.py', index,
-                            '-ql', '--language', language] + extra_args,
-                            env=os.environ)
+            r = subprocess.run(['python', 'qarakusi.am.py', index,
+                                '-ql', '--language', language] + extra_args,
+                                env=os.environ)
+            if r.returncode:
+                exit(r.returncode)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I didn't check the return code of the manim run (0 for success, nonzero otherwise).
Currently I exit with the same exit code for failed manim tests.